### PR TITLE
Drop edown fork and use upstream instead

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 
 {lib_dirs, ["deps"]}.
 
-{deps, [{edown, ".*", {git, "git://github.com/esl/edown.git", {tag, "0.4"}}}]}.
+{deps, [{edown, ".*", {git, "https://github.com/uwiger/edown.git", {tag, "0.8.1"}}}]}.
 
 {edoc_opts, [{doclet, edown_doclet}]}.
 


### PR DESCRIPTION
Upstream is better maintained and is already prepared to handle with the breaking changes introduced from OTP18 onwards
